### PR TITLE
Add android-lint-summary to mobile list

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Wrappers:
 * [FlowDroid](https://github.com/secure-software-engineering/soot-infoflow-android) - static taint analysis tool for Android applications
 * [paprika](https://github.com/GeoffreyHecht/paprika) - A toolkit to detect some code smells in analyzed Android applications.
 * [qark](https://github.com/linkedin/qark) - Tool to look for several security related Android application vulnerabilities
+* [android-lint-summary](https://github.com/passy/android-lint-summary) - Combines lint errors of multiple projects into one output, check lint results of multiple sub-projects at once.
 
 ## Packages
 


### PR DESCRIPTION
Combines lint errors of multiple projects into one output, check lint results of multiple sub-projects at once